### PR TITLE
Fix debug program path

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
             "name": "Debug Push_Swap",
             "type": "cppdbg",
             "request": "launch",
-            "program": "/home/ari/Escritorio/push_swap/src/test_parse",
+            "program": "${workspaceFolder}/src/push_swap",
             "args": ["2", "3", "1"], // Puedes poner los argumentos de prueba aquí
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}",


### PR DESCRIPTION
## Summary
- fix .vscode debug configuration to use `${workspaceFolder}` instead of an absolute path

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6843a1191b188322b67a49cdd710f583