### PR TITLE
Fix ft_split delimiter handling

### DIFF
--- a/src/parse/split.c
+++ b/src/parse/split.c
@@ -64,7 +64,7 @@ char    **ft_split(const char *s, char c)
     {
         if (s[i] != c && start < 0 )
             start = i;
-        else if ((s[i] == c || s[i + 1] == '\0') && start >= 0)
+        if ((s[i] == c || s[i + 1] == '\0') && start >= 0)
         {
             if (s[i] == c)
                 len = i - start;


### PR DESCRIPTION
## Summary
- ensure delimiter check runs independently in `ft_split`
- run project build and tests

## Testing
- `make`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843afa3c6248322bae04a8860d12db4