### PR TITLE
Add performance tests for push_swap

### DIFF
--- a/tests/test_sort_moves.py
+++ b/tests/test_sort_moves.py
@@ -33,6 +33,13 @@ def test_five_specific():
 def test_hundred_reverse():
     numbers = [str(i) for i in range(100, 0, -1)]
     ops = run_push_swap(numbers)
-    # La nueva estrategia debe generar menos movimientos que la version anterior
-    assert len(ops) < 1084
+    # Debe ordenar en menos de 700 instrucciones
+    assert len(ops) < 700
+
+
+def test_five_hundred_reverse():
+    numbers = [str(i) for i in range(500, 0, -1)]
+    ops = run_push_swap(numbers)
+    # Debe ordenar en menos de 5500 instrucciones
+    assert len(ops) < 5500
 


### PR DESCRIPTION
## Summary
- enforce stricter move limits for 100-number case
- add test for sorting 500 numbers under 5500 moves

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847392dc428832281c4667e77254397