### PR TITLE
Refactor assign_indexes for Norminette

### DIFF
--- a/src/algorithm/assign_indexes.c
+++ b/src/algorithm/assign_indexes.c
@@ -1,54 +1,81 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   assign_indexes.c                                   :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: codex <codex@student.42.fr>                +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/06/06 00:00:00 by codex             #+#    #+#             */
+/*   Updated: 2024/06/06 00:00:00 by codex            ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
 #include "push_swap.h"
 
-void assign_indexes(t_node *stack)
+static int	*stack_to_array(t_node *stack, int size)
 {
-    int     size;
-    int     *arr;
-    int     i;
-    int     j;
-    t_node  *tmp;
+	int		*arr;
+	int		i;
 
-    size = stack_size(stack);
-    arr = malloc(sizeof(int) * size);
-    if (!arr)
-        return;
-    tmp = stack;
-    i = 0;
-    while (tmp)
-    {
-        arr[i++] = tmp->value;
-        tmp = tmp->next;
-    }
-    i = 0;
-    while (i < size - 1)
-    {
-        j = i + 1;
-        while (j < size)
-        {
-            if (arr[i] > arr[j])
-            {
-                int swap = arr[i];
-                arr[i] = arr[j];
-                arr[j] = swap;
-            }
-            j++;
-        }
-        i++;
-    }
-    tmp = stack;
-    while (tmp)
-    {
-        i = 0;
-        while (i < size)
-        {
-            if (arr[i] == tmp->value)
-            {
-                tmp->index = i;
-                break;
-            }
-            i++;
-        }
-        tmp = tmp->next;
-    }
-    free(arr);
+	arr = malloc(sizeof(int) * size);
+	if (!arr)
+		return (NULL);
+	i = 0;
+	while (stack)
+	{
+		arr[i++] = stack->value;
+		stack = stack->next;
+	}
+	return (arr);
+}
+
+static void	sort_array(int *arr, int size)
+{
+	int	i;
+	int	j;
+	int	tmp;
+
+	i = 0;
+	while (i < size - 1)
+	{
+		j = i + 1;
+		while (j < size)
+		{
+			if (arr[i] > arr[j])
+			{
+				tmp = arr[i];
+				arr[i] = arr[j];
+				arr[j] = tmp;
+			}
+			j++;
+		}
+		i++;
+	}
+}
+
+static void	set_indexes(t_node *stack, int *arr, int size)
+{
+	int	i;
+
+	while (stack)
+	{
+		i = 0;
+		while (i < size && arr[i] != stack->value)
+			i++;
+		stack->index = i;
+		stack = stack->next;
+	}
+}
+
+void	assign_indexes(t_node *stack)
+{
+	int		size;
+	int		*arr;
+
+	size = stack_size(stack);
+	arr = stack_to_array(stack, size);
+	if (!arr)
+		return ;
+	sort_array(arr, size);
+	set_indexes(stack, arr, size);
+	free(arr);
 }


### PR DESCRIPTION
## Summary
- add a proper 42 header for `assign_indexes.c`
- refactor logic into helper functions
- use tabs to satisfy Norminette indentation rules

## Testing
- `make -j$(nproc)`
- `pytest -q test/tests` *(fails: missing test sources)*

------
https://chatgpt.com/codex/tasks/task_e_684ce628852c8322bb7b87898ce75f76