### PR TITLE
Fix Norminette issues in stack_utils

### DIFF
--- a/src/algorithm/stack_utils.c
+++ b/src/algorithm/stack_utils.c
@@ -1,14 +1,26 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   stack_utils.c                                      :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: codex <codex@student.42.fr>                +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/06/06 00:00:00 by codex             #+#    #+#             */
+/*   Updated: 2024/06/06 00:00:00 by codex            ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
 #include "push_swap.h"
 
-int stack_size(t_node *stack)
+int	stack_size(t_node *stack)
 {
-    int size;
+	int		size;
 
-    size = 0;
-    while (stack)
-    {
-        size++;
-        stack = stack->next;
-    }
-    return size;
+	size = 0;
+	while (stack)
+	{
+		size++;
+		stack = stack->next;
+	}
+	return (size);
 }


### PR DESCRIPTION
## Summary
- add 42 header to `stack_utils.c`
- use tabs and parentheses to satisfy Norminette

## Testing
- `make`
- `pytest -q` *(fails: missing test sources)*

------
https://chatgpt.com/codex/tasks/task_e_684cedb36aac8322986c6819aa51122c