### PR TITLE
Fix Norminette style for push_ops

### DIFF
--- a/src/movements/push_ops.c
+++ b/src/movements/push_ops.c
@@ -1,18 +1,30 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   push_ops.c                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: codex <codex@student.42.fr>                +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/06/06 00:00:00 by codex             #+#    #+#             */
+/*   Updated: 2024/06/06 00:00:00 by codex            ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
 #include "push_swap.h"
 #include <unistd.h>
 
-void pa(t_node **a, t_node **b)
+void	pa(t_node **a, t_node **b)
 {
-    if (!b || !*b)
-        return;
-    push_node(a, b);
-    write(1, "pa\n", 3);
+	if (!b || !*b)
+		return ;
+	push_node(a, b);
+	write(1, "pa\n", 3);
 }
 
-void pb(t_node **a, t_node **b)
+void	pb(t_node **a, t_node **b)
 {
-    if (!a || !*a)
-        return;
-    push_node(b, a);
-    write(1, "pb\n", 3);
+	if (!a || !*a)
+		return ;
+	push_node(b, a);
+	write(1, "pb\n", 3);
 }


### PR DESCRIPTION
## Summary
- apply 42 header to `push_ops.c`
- fix spacing and tabbing so Norminette passes

## Testing
- `norminette src/movements/push_ops.c`
- `make`
- `pytest -q` *(fails: missing test build targets)*

------
https://chatgpt.com/codex/tasks/task_e_684cfebcff448322b35d5a0a2bbd6ec2