### PR TITLE
Fix norminette issues in rotate_ops.c

### DIFF
--- a/src/movements/rotate_ops.c
+++ b/src/movements/rotate_ops.c
@@ -1,37 +1,49 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   rotate_ops.c                                      :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: codex <codex@student.42.fr>                +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/06/06 00:00:00 by codex             #+#    #+#             */
+/*   Updated: 2024/06/06 00:00:00 by codex            ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
 #include "push_swap.h"
 #include <unistd.h>
 
-void ra(t_node **a)
+void	ra(t_node **a)
 {
-    if (!a || !*a || !(*a)->next)
-        return;
-    rotate_nodes(a);
-    write(1, "ra\n", 3);
+	if (!a || !*a || !(*a)->next)
+		return ;
+	rotate_nodes(a);
+	write(1, "ra\n", 3);
 }
 
-void rb(t_node **b)
+void	rb(t_node **b)
 {
-    if (!b || !*b || !(*b)->next)
-        return;
-    rotate_nodes(b);
-    write(1, "rb\n", 3);
+	if (!b || !*b || !(*b)->next)
+		return ;
+	rotate_nodes(b);
+	write(1, "rb\n", 3);
 }
 
-void rr(t_node **a, t_node **b)
+void	rr(t_node **a, t_node **b)
 {
-    int performed;
+	int	performed;
 
-    performed = 0;
-    if (a && *a && (*a)->next)
-    {
-        rotate_nodes(a);
-        performed = 1;
-    }
-    if (b && *b && (*b)->next)
-    {
-        rotate_nodes(b);
-        performed = 1;
-    }
-    if (performed)
-        write(1, "rr\n", 3);
+	performed = 0;
+	if (a && *a && (*a)->next)
+	{
+		rotate_nodes(a);
+		performed = 1;
+	}
+	if (b && *b && (*b)->next)
+	{
+		rotate_nodes(b);
+		performed = 1;
+	}
+	if (performed)
+		write(1, "rr\n", 3);
 }


### PR DESCRIPTION
## Summary
- add missing 42 header to rotate_ops.c
- use tabs for indentation and return properly

## Testing
- `norminette src/movements/rotate_ops.c`
- `pytest -q` *(fails: missing test sources)*

------
https://chatgpt.com/codex/tasks/task_e_684dc15701d08322842a68e7aba55306