### PR TITLE
Fix norminette issues

### DIFF
--- a/src/movements/swap_ops.c
+++ b/src/movements/swap_ops.c
@@ -1,37 +1,49 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   swap_ops.c                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: codex <codex@student.42.fr>                +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/06/06 00:00:00 by codex             #+#    #+#             */
+/*   Updated: 2024/06/06 00:00:00 by codex            ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
 #include "push_swap.h"
 #include <unistd.h>
 
-void sa(t_node **a)
+void	sa(t_node **a)
 {
-    if (!a || !*a || !(*a)->next)
-        return;
-    swap_nodes(a);
-    write(1, "sa\n", 3);
+	if (!a || !*a || !(*a)->next)
+		return ;
+	swap_nodes(a);
+	write(1, "sa\n", 3);
 }
 
-void sb(t_node **b)
+void	sb(t_node **b)
 {
-    if (!b || !*b || !(*b)->next)
-        return;
-    swap_nodes(b);
-    write(1, "sb\n", 3);
+	if (!b || !*b || !(*b)->next)
+		return ;
+	swap_nodes(b);
+	write(1, "sb\n", 3);
 }
 
-void ss(t_node **a, t_node **b)
+void	ss(t_node **a, t_node **b)
 {
-    int performed;
+	int	performed;
 
-    performed = 0;
-    if (a && *a && (*a)->next)
-    {
-        swap_nodes(a);
-        performed = 1;
-    }
-    if (b && *b && (*b)->next)
-    {
-        swap_nodes(b);
-        performed = 1;
-    }
-    if (performed)
-        write(1, "ss\n", 3);
+	performed = 0;
+	if (a && *a && (*a)->next)
+	{
+		swap_nodes(a);
+		performed = 1;
+	}
+	if (b && *b && (*b)->next)
+	{
+		swap_nodes(b);
+		performed = 1;
+	}
+	if (performed)
+		write(1, "ss\n", 3);
 }


### PR DESCRIPTION
## Summary
- add 42 header to `swap_ops.c`
- fix indentation and spacing to satisfy norminette

## Testing
- `make -C test -f Makefile.src` *(fails: No rule to make target 'main.o')*
- `norminette src/movements/swap_ops.c`

------
https://chatgpt.com/codex/tasks/task_e_684dc2c2da8c8322b8fb9e2b8d539855