### PR TITLE
Fix norminette issues in atoi_utils

### DIFF
--- a/src/parse/atoi_utils.c
+++ b/src/parse/atoi_utils.c
@@ -1,32 +1,51 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   atoi_utils.c                                      :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: codex <codex@student.42.fr>                +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/06/06 00:00:00 by codex             #+#    #+#             */
+/*   Updated: 2024/06/06 00:00:00 by codex            ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
 #include "push_swap.h"
 
-int ft_atoi_push_swap(const char *str, int *error_flag)
+static int	parse_sign(const char *str, int *i)
 {
-    long    result;
-    int     sign;
-    int     i;
+	int		sign;
 
-    result = 0;
-    sign = 1;
-    i = 0;
-    *error_flag = 0;
+	sign = 1;
+	if (str[*i] == '-' || str[*i] == '+')
+	{
+		if (str[*i] == '-')
+			sign = -1;
+		(*i)++;
+	}
+	return (sign);
+}
 
-    if (str[i] == '-' || str[i] == '+')
-    {
-        if (str[i] == '-')
-            sign = -1;
-        i++;
-    }
+int	ft_atoi_push_swap(const char *str, int *error_flag)
+{
+	long	result;
+	int		sign;
+	int		i;
 
-    while (str[i])
-    {
-        result = result * 10 + (str[i] - '0');
-        if ((sign == 1 && result > INT_MAX) || (sign == -1 && -result < INT_MIN))
-        {
-            *error_flag = 1;
-            return 0;
-        }
-        i++;
-    }
-    return ((int)(result *sign));
+	result = 0;
+	i = 0;
+	sign = parse_sign(str, &i);
+	*error_flag = 0;
+	while (str[i])
+	{
+		result = result * 10 + (str[i] - '0');
+		if ((sign == 1 && result > INT_MAX)
+			|| (sign == -1 && (-result) < INT_MIN))
+		{
+			*error_flag = 1;
+			return (0);
+		}
+		i++;
+	}
+	return ((int)(result * sign));
 }


### PR DESCRIPTION
## Summary
- add 42-style header and helper function
- align variables and break long condition
- ensure `ft_atoi_push_swap` passes Norminette

## Testing
- `norminette src/parse/atoi_utils.c`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_684dc578401483228427fcfdeb4584c2