### PR TITLE
Fix norminette style for free_utils.c

### DIFF
--- a/src/parse/free_utils.c
+++ b/src/parse/free_utils.c
@@ -1,23 +1,35 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   free_utils.c                                       :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: codex <codex@student.42.fr>                +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/06/06 00:00:00 by codex             #+#    #+#             */
+/*   Updated: 2024/06/06 00:00:00 by codex            ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
 #include "push_swap.h"
 
-void free_split(char **tokens)
+void	free_split(char **tokens)
 {
-    int     i;
+	int		i;
 
-    if (!tokens)
-        return ;
-    i = 0;
-    while (tokens[i])
-    {
-        free(tokens[i]);
-        i++;
-    }
-    free(tokens);
+	if (!tokens)
+		return ;
+	i = 0;
+	while (tokens[i])
+	{
+		free(tokens[i]);
+		i++;
+	}
+	free(tokens);
 }
 
 void	free_stack(t_node **stack)
 {
-	t_node	*tmp;
+	t_node		*tmp;
 
 	while (*stack)
 	{
@@ -27,13 +39,15 @@ void	free_stack(t_node **stack)
 	}
 }
 
-void free_tokens(char **tokens, int count)
+void	free_tokens(char **tokens, int count)
 {
-    int i = 0;
-    while (i < count)
-    {
-        free(tokens[i]);
-        i++;
-    }
-    free(tokens);
+	int		i;
+
+	i = 0;
+	while (i < count)
+	{
+		free(tokens[i]);
+		i++;
+	}
+	free(tokens);
 }


### PR DESCRIPTION
## Summary
- format `free_utils.c` according to the 42 norminette guidelines

## Testing
- `norminette src/parse/free_utils.c`
- `make`
- `pytest -q` *(fails: missing test files)*

------
https://chatgpt.com/codex/tasks/task_e_684dc87742108322b3ad1d1530598a86