### PR TITLE
Fix norminette errors in parse_input

### DIFF
--- a/src/parse/parse_input.c
+++ b/src/parse/parse_input.c
@@ -1,94 +1,115 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   parse_input.c                                     :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: codex <codex@student.42.fr>                +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/06/06 00:00:00 by codex             #+#    #+#             */
+/*   Updated: 2024/06/06 00:00:00 by codex            ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
 #include "push_swap.h"
 
-static int has_duplicates(t_node *stack)
+static int	has_duplicates(t_node *stack)
 {
-    t_node  *current;
-    t_node  *runner;
+	t_node	*current;
+	t_node	*runner;
 
-    current = stack;
-    while (current)
-    {
-        runner = current->next;
-        while (runner)
-        {
-            if (current->value == runner->value)
-                return 1;
-            runner = runner->next;
-        }
-        current = current->next;
-    }
-    return 0;
+	current = stack;
+	while (current)
+	{
+		runner = current->next;
+		while (runner)
+		{
+			if (current->value == runner->value)
+				return (1);
+			runner = runner->next;
+		}
+		current = current->next;
+	}
+	return (0);
 }
 
-char    **split_args(int argc, char **argv)
+static int	append_tokens(char **tokens, char **split, int *k)
 {
-    char    **tokens;
-    char    **split;
-    int     total;
-    int     i;
-    int     j;
-    int     k;
+	int	j;
 
-    total = count_all_tokens(argc, argv);
-    tokens = malloc(sizeof(char *) * (total + 1));
-    if (!tokens)
-        return (NULL);
-    i = 1;
-    k = 0;
-    while (i < argc)
-    {
-        split = ft_split(argv[i], ' ');
-        if (!split)
-        {
-            free_tokens(tokens, k);
-            return (NULL);
-        }
-        j = 0;
-        while (split[j])
-        {
-            tokens[k] = ft_strdup(split[j]);
-            if (!tokens[k])
-            {
-                free_split(split);
-                free_tokens(tokens, k);
-                return (NULL);
-            }
-            k++;
-            j++;
-        }
-        free_split(split);
-        i++;
-    }
-    tokens[k] = NULL;
-    return (tokens);
+	j = 0;
+	while (split[j])
+	{
+		tokens[*k] = ft_strdup(split[j]);
+		if (!tokens[*k])
+		{
+			free_split(split);
+			return (0);
+		}
+		(*k)++;
+		j++;
+	}
+	free_split(split);
+	return (1);
 }
 
-t_node *parse_input(int argc, char **argv)
+char	**split_args(int argc, char **argv)
 {
-    char    **tokens;
-    int     i;
-    t_node  *stack;
+	char	**tokens;
+	char	**split;
+	int		i;
+	int		k;
 
-    tokens = split_args(argc, argv);
-    i = 0;
-    stack = NULL;
-    if (!tokens)
-        return NULL;
-    while (tokens[i])
-    {
-        if (!is_valid_number(tokens[i]) || !add_node(&stack, tokens[i]))
-        {
-            free_split(tokens);
-            free_stack(&stack);
-            return NULL;
-        }
-        i++;
-    }
-    free_split(tokens);
-    if (has_duplicates(stack))
-    {
-        free_stack(&stack);
-        return NULL;
-    }
-    return stack;
+	tokens = malloc(sizeof(char *) * (count_all_tokens(argc, argv) + 1));
+	if (!tokens)
+		return (NULL);
+	i = 1;
+	k = 0;
+	while (i < argc)
+	{
+		split = ft_split(argv[i], ' ');
+		if (!split || !append_tokens(tokens, split, &k))
+		{
+			free_tokens(tokens, k);
+			return (NULL);
+		}
+		i++;
+	}
+	tokens[k] = NULL;
+	return (tokens);
+}
+
+static int	add_arguments(t_node **stack, char **tokens)
+{
+	int	i;
+
+	i = 0;
+	while (tokens[i])
+	{
+		if (!is_valid_number(tokens[i]) || !add_node(stack, tokens[i]))
+			return (0);
+		i++;
+	}
+	return (1);
+}
+
+t_node	*parse_input(int argc, char **argv)
+{
+	char	**tokens;
+	t_node	*stack;
+
+	tokens = split_args(argc, argv);
+	stack = NULL;
+	if (!tokens || !add_arguments(&stack, tokens))
+	{
+		free_split(tokens);
+		free_stack(&stack);
+		return (NULL);
+	}
+	free_split(tokens);
+	if (has_duplicates(stack))
+	{
+		free_stack(&stack);
+		return (NULL);
+	}
+	return (stack);
 }


### PR DESCRIPTION
## Summary
- refactor `parse_input.c`
  - add the missing 42 header
  - align indentation with tabs and fix variable alignment
  - split logic into helper functions to satisfy Norminette line limits

## Testing
- `norminette src/parse/parse_input.c`

------
https://chatgpt.com/codex/tasks/task_e_684dcc94dc048322b3de89131c4b5335