### PR TITLE
Fix norm errors in split.c

### DIFF
--- a/src/parse/split.c
+++ b/src/parse/split.c
@@ -1,86 +1,108 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   split.c                                            :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: codex <codex@student.42.fr>                +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/06/06 00:00:00 by codex             #+#    #+#             */
+/*   Updated: 2024/06/06 00:00:00 by codex            ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
 #include "push_swap.h"
 
-static int word_count(const char *s, char c)
+static int	word_count(const char *s, char c)
 {
-    int     count;
-    int     in_word;
-    count = 0;
-    in_word = 0;
+	int		count;
+	int		in_word;
 
-    while (*s)
-    {
-        if (*s != c && in_word == 0)
-        {
-            in_word = 1;
-            count++;
-        }
-        else if (*s == c)
-            in_word = 0;
-        s++;
-    }
-    return count;
+	count = 0;
+	in_word = 0;
+	while (*s)
+	{
+		if (*s != c && in_word == 0)
+		{
+			in_word = 1;
+			count++;
+		}
+		else if (*s == c)
+			in_word = 0;
+		s++;
+	}
+	return (count);
 }
 
-static char *word_dup(const char *start, int len)
+static char	*word_dup(const char *start, int len)
 {
-    char    *word;
-    int     i;
-    i = 0;
+	char	*word;
+	int		i;
 
-    word = malloc(sizeof(char) * (len + 1));
-    if (!word)
-        return (NULL);
-    while (i < len)
-    {
-        word[i] = start[i];
-        i++;
-    }
-    word[i] = '\0';
-    return (word);
+	i = 0;
+	word = malloc(sizeof(char) * (len + 1));
+	if (!word)
+		return (NULL);
+	while (i < len)
+	{
+		word[i] = start[i];
+		i++;
+	}
+	word[i] = '\0';
+	return (word);
 }
 
-static void free_all(char **result, int i)
+static void	free_all(char **result, int i)
 {
-    while (i--)
-        free(result[i]);
-    free(result);
+	while (i--)
+		free(result[i]);
+	free(result);
 }
 
-
-char    **ft_split(const char *s, char c)
+static int	populate_words(char **res, const char *s, char c, int *k)
 {
-    char    **result;
-    int     i = 0;
-    int     start = -1;
-    int     k = 0;
-    int     len;
+	int		i;
+	int		start;
+	int		len;
 
-    if (!s)
-        return NULL;
-    result = malloc(sizeof(char *) * (word_count(s, c) + 1));
-    if (!result)
-        return (NULL);
-    while (s[i])
-    {
-        if (s[i] != c && start < 0 )
-            start = i;
-        if ((s[i] == c || s[i + 1] == '\0') && start >= 0)
-        {
-            if (s[i] == c)
-                len = i - start;
-            else
-                len = i - start + 1;
-            result[k] = word_dup(s + start, len);
-            if (!result[k])
-            {
-                free_all(result, k);
-                return NULL;
-            }
-            k++;
-            start = -1;
-        }
-        i++;
-    }
-    result[k] = NULL;
-    return result;
+	i = 0;
+	start = -1;
+	while (s[i])
+	{
+		if (s[i] != c && start < 0)
+			start = i;
+		if ((s[i] == c || s[i + 1] == '\0') && start >= 0)
+		{
+			if (s[i] == c)
+				len = i - start;
+			else
+				len = i - start + 1;
+			res[*k] = word_dup(s + start, len);
+			if (!res[*k])
+				return (0);
+			(*k)++;
+			start = -1;
+		}
+		i++;
+	}
+	return (1);
+}
+
+char	**ft_split(const char *s, char c)
+{
+	char	**result;
+	int		k;
+
+	if (!s)
+		return (NULL);
+	result = malloc(sizeof(char *) * (word_count(s, c) + 1));
+	if (!result)
+		return (NULL);
+	k = 0;
+	if (!populate_words(result, s, c, &k))
+	{
+		free_all(result, k);
+		return (NULL);
+	}
+	result[k] = NULL;
+	return (result);
 }


### PR DESCRIPTION
## Summary
- add 42 header and reformat `ft_split` helpers
- ensure functions have proper indentation and line lengths
- inline word allocation logic to meet Norminette limits

## Testing
- `make`
- `norminette src/parse/split.c`

------
https://chatgpt.com/codex/tasks/task_e_684dcfd15c848322869481c5eef4c9dc