### PR TITLE
Fix norm issues in parse_utils.c

### DIFF
--- a/src/parse/parse_utils.c
+++ b/src/parse/parse_utils.c
@@ -1,79 +1,99 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   parse_utils.c                                      :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: codex <codex@student.42.fr>                +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/06/06 00:00:00 by codex             #+#    #+#             */
+/*   Updated: 2024/06/06 00:00:00 by codex            ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
 #include "push_swap.h"
 
-int count_all_tokens(int argc, char **argv)
+int	count_all_tokens(int argc, char **argv)
 {
-    int     i;
-    int     count;
-    char    **split;
-    int     j;
+	int		i;
+	int		count;
+	char		**split;
+	int		j;
 
-    i = 1;
-    count = 0;
-    while (i < argc)
-    {
-        split = ft_split(argv[i], ' ');
-        if (!split)
-            return 0;
-        j = 0;
-        while (split[j++])
-            count++;
-        free_split(split);
-        i++;
-    }
-    return count;
+	i = 1;
+	count = 0;
+	while (i < argc)
+	{
+		split = ft_split(argv[i], ' ');
+		if (!split)
+			return (0);
+		j = 0;
+		while (split[j++])
+			count++;
+		free_split(split);
+		i++;
+	}
+	return (count);
 }
 
-int is_valid_number(const char *str)
+int	is_valid_number(const char *str)
 {
-    int     i;
+	int		i;
 
-    if (!str || !str[0])
-        return (0);
+	if (!str || !str[0])
+		return (0);
 
-    i = 0;
-    if (str[0] == '-' || str[0] == '+')
-        i++;
+	i = 0;
+	if (str[0] == '-' || str[0] == '+')
+		i++;
 
-    if (!str[i])
-        return 0;
+	if (!str[i])
+		return (0);
 
-    while (str[i])
-    {
-        if (str[i] < '0' || str[i] > '9')
-            return 0;
-        i++;
-    }
-    return 1;
+	while (str[i])
+	{
+		if (str[i] < '0' || str[i] > '9')
+			return (0);
+		i++;
+	}
+	return (1);
 }
 
-int add_node(t_node **stack, const char *str)
+static t_node	*create_node(const char *str, int *error)
 {
-    t_node  *new;
-    t_node  *temp;
-    int     value;
-    int     error;
+	t_node	*new;
 
-    error = 0;
-    value = ft_atoi_push_swap(str, &error);
-    if (error)
-        return (0);
-    new = malloc(sizeof(t_node));
-    if (!new)
-        return (0);
-    new->value = value;
-    new->index = -1;
-    new->next = NULL;
-    if (!*stack)
-    {
-        *stack = new;
-        return (1);
-    }
-    else
-    {
-        temp = *stack;
-        while (temp->next)
-            temp = temp->next;
-        temp->next = new;
-    }
-    return (1);
+	*error = 0;
+	new = malloc(sizeof(t_node));
+	if (!new)
+		return (NULL);
+	new->value = ft_atoi_push_swap(str, error);
+	if (*error)
+	{
+		free(new);
+		return (NULL);
+	}
+	new->index = -1;
+	new->next = NULL;
+	return (new);
+}
+
+int	add_node(t_node **stack, const char *str)
+{
+	t_node	*new;
+	t_node	*temp;
+	int		error;
+
+	new = create_node(str, &error);
+	if (!new)
+		return (0);
+	if (!*stack)
+	{
+		*stack = new;
+		return (1);
+	}
+	temp = *stack;
+	while (temp->next)
+		temp = temp->next;
+	temp->next = new;
+	return (1);
 }


### PR DESCRIPTION
## Summary
- add 42 header to `parse_utils.c`
- replace spaces with tabs for norm compliance
- refactor `add_node` and introduce helper `create_node`

## Testing
- `pytest -q test/tests` *(fails: parser test compilation error)*

------
https://chatgpt.com/codex/tasks/task_e_684dd1e0a3908322ae9543cd0181a71f