### PR TITLE
Fix spacing and add header for string_utils

### DIFF
--- a/src/parse/string_utils.c
+++ b/src/parse/string_utils.c
@@ -1,23 +1,36 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   string_utils.c                                     :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: codex <codex@student.42.fr>                +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2024/06/06 00:00:00 by codex             #+#    #+#             */
+/*   Updated: 2024/06/06 00:00:00 by codex            ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
 #include "push_swap.h"
 
-char    *ft_strdup(const char *s)
+char	*ft_strdup(const char *s)
 {
-    char    *dup;
-    int     len;
-    int     i;
+	char		*dup;
+	int		len;
+	int		i;
 
-    len = 0;
-    while (s[len])
-        len++;
-    dup = malloc(sizeof(char) * (len + 1));
-    if (!dup)
-        return NULL;
-    i = 0;
-    while (i < len)
-    {
-        dup[i] = s[i];
-        i++;
-    }
-    dup[i] = '\0';
-    return dup;
+	len = 0;
+	while (s[len])
+		len++;
+	dup = malloc(sizeof(char) * (len + 1));
+	if (!dup)
+		return (NULL);
+	i = 0;
+	while (i < len)
+	{
+		dup[i] = s[i];
+		i++;
+	}
+	dup[i] = '\0';
+	return (dup);
 }
+


### PR DESCRIPTION
## Summary
- add Norm-compliant header to `string_utils.c`
- convert spaces to tabs and fix return statements

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_684ddb27b7d883229a1701e5bced84b8