### PR TITLE
Fix Norminette newline rule

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -12,6 +12,7 @@
 
 #include "push_swap.h"
 #include <unistd.h>
+
 static int	has_only_spaces(const char *s)
 {
 	int	i;


### PR DESCRIPTION
## Summary
- ensure newline after include statements in `main.c`

## Testing
- `pytest -q` *(fails: missing test resources)*

------
https://chatgpt.com/codex/tasks/task_e_684de2a454988322b4fac133f0a9ac80